### PR TITLE
Fixes traceback when flickr_api.upload() photo_file string is unicode

### DIFF
--- a/flickr_api/multipart.py
+++ b/flickr_api/multipart.py
@@ -50,6 +50,7 @@ def encode_multipart_formdata(fields, files):
         L.append('')
         L.append(value)
     for (key, filename, value) in files:
+        filename = filename.encode("utf8")
         L.append('--' + BOUNDARY)
         L.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename))
         L.append('Content-Type: %s' % get_content_type(filename))


### PR DESCRIPTION
Potentially fixes issue https://github.com/alexis-mignon/python-flickr-api/issues/19 as long as it causes no regressions.
