### PR TITLE
Fix bug where api.Person.getFromToken(token=token) failed.

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -739,7 +739,7 @@ class Person(FlickrObject):
         if token is None:
             token = auth.token_factory(filename=filename, token_key=token_key,
                                        token_secret=token_secret)
-        return test.login(token)
+        return test.login(token=token)
 
     @static_caller("flickr.people.findByEmail")
     def findByEmail(find_email):


### PR DESCRIPTION
`test.login` is decorated by `static_caller`, which takes `token` as a position arguments, thus no token can be used to issue the API call.
