### PR TITLE
Uses Pillow for Image processing

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -25,12 +25,19 @@ from reflection import caller, static_caller, FlickrAutoDoc
 import urllib2
 from UserList import UserList
 import auth
+import warnings
+from cStringIO import StringIO
 
 try:
-    import Image
-    import cStringIO
+    from PIL import Image    
 except ImportError:
-    pass
+    class Image(object):
+        @staticmethod
+        def open(*args, **kwargs):
+            image_module_404 = "\nThe PIL package was not found on this system. Images cannot be displayed." \
+                "\nConsider installing PIL or Pillow."
+            warnings.warn(image_module_404)
+            raise RuntimeError("Image module not found.")
 
 
 def dict_converter(keys, func):
@@ -1338,7 +1345,7 @@ class Photo(FlickrObject):
         if size_label is None:
             size_label = self._getLargestSizeLabel()
         r = urllib2.urlopen(self.getPhotoFile(size_label))
-        b = cStringIO.StringIO(r.read())
+        b = StringIO(r.read())
         Image.open(b).show()
 
     @static_caller("flickr.photos.getUntagged")


### PR DESCRIPTION
`flickr_api.objects.Photo.show` was raising an Exception.
```bash
In [2]: photo.show('Square')
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-273cd7b12160> in <module>()
----> 1 photo.show('Square')

/Users/eloy/Code/python-flickr-api/flickr_api/objects.py in show(self, size_label)
   1339             size_label = self._getLargestSizeLabel()
   1340         r = urllib2.urlopen(self.getPhotoFile(size_label))
-> 1341         b = cStringIO.StringIO(r.read())
   1342         Image.open(b).show()
   1343 

NameError: global name 'cStringIO' is not defined
```
I'm using `Python 2.7.8` on a Macbook Air OS 10.10.2
`Pillow` has been good to me.

Thanks for the project!  Loads of help deleting photo sets by name.  Helped a lot.  Ended up making a shell that I used while command-line batch editing photos.  If you're interested I'd love to share as Pull-Request.  Warning it's dependent on `iPython`.

