### PR TITLE
Don't include version number in Pypi link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also install the last stable release using the `pip` progam:
 $ pip install flickr_api --user  # to install in the user directory (~/.local)
 $ sudo pip install flickr_api    # to install globally
 ```
-See its [Pypi page](https://pypi.python.org/pypi/flickr_api/0.4).
+See its [Pypi page](https://pypi.python.org/pypi/flickr_api).
 
 Tutorial
 --------


### PR DESCRIPTION
That way, the link will always stay up-to-date.