### PR TITLE
Python 3 support

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,6 +1,7 @@
 Requires:
- - python 2.6+
- - python-oauth package (python module from http://code.google.com/p/oauth/)
+ - python 2.7+
+ - python-oauth2 package
+ - python six package
 
 1) Extract the archive
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Main features
 Requires
 --------
 	* python >= 2.6.5 
-	* python-oauth (or the python module from http://code.google.com/p/oauth/)
-	* six
+	* [python-oauth2](https://github.com/joestump/python-oauth2)
+	* [six](https://github.com/benjaminp/six)
 
-[![githalytics.com alpha](https://cruel-carlota.pagodabox.com/950bd311453e675e4a06ec3a5e99e420 "githalytics.com")](http://githalytics.com/alexis-mignon/python-flickr-api)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Main features
 
 Requires
 --------
-	* python >= 2.6.5 
-	* [python-oauth2](https://github.com/joestump/python-oauth2)
-	* [six](https://github.com/benjaminp/six)
+  * python >= 2.7
+  * [python-oauth2](https://github.com/joestump/python-oauth2)
+  * [six](https://github.com/benjaminp/six)
 
 
 Installation

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Requires
 --------
 	* python >= 2.6.5 
 	* python-oauth (or the python module from http://code.google.com/p/oauth/)
+	* six
 
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/950bd311453e675e4a06ec3a5e99e420 "githalytics.com")](http://githalytics.com/alexis-mignon/python-flickr-api)
 

--- a/flickr_api/__init__.py
+++ b/flickr_api/__init__.py
@@ -20,16 +20,19 @@
     Date   : 05/08/2011
 
 """
-try:
-    from objects import *
-    import objects
-    import upload as Upload
-    from upload import upload, replace
-except Exception, e:
-    print "Could not load all modules"
-    print type(e), e
 
-from auth import set_auth_handler
-from method_call import enable_cache, disable_cache
-from keys import set_keys
-from _version import __version__
+from __future__ import print_function
+
+try:
+    from .objects import *
+    from . import objects
+    from .upload import upload as Upload
+    from .upload import upload, replace
+except Exception as e:
+    print ("Could not load all modules")
+    print (type(e), e)
+
+from .auth import set_auth_handler
+from .method_call import enable_cache, disable_cache
+from .keys import set_keys
+from ._version import __version__

--- a/flickr_api/auth.py
+++ b/flickr_api/auth.py
@@ -40,8 +40,8 @@ except ImportError:
     import oauth
 
 import time
-import urlparse
-import urllib2
+from six import string_types
+from six.moves import urllib
 from . import keys
 
 TOKEN_REQUEST_URL = "https://www.flickr.com/services/oauth/request_token"
@@ -86,8 +86,8 @@ class AuthHandler(object):
                                      parameters=params)
             req.sign_request(oauth.OAuthSignatureMethod_HMAC_SHA1(),
                              self.consumer, None)
-            resp = urllib2.urlopen(req.to_url())
-            request_token = dict(urlparse.parse_qsl(resp.read()))
+            resp = urllib.request.urlopen(req.to_url())
+            request_token = dict(urllib.parse.parse_qsl(resp.read()))
             self.request_token = oauth.OAuthToken(
                 request_token['oauth_token'],
                 request_token['oauth_token_secret']
@@ -138,8 +138,8 @@ class AuthHandler(object):
                                  parameters=access_token_parms)
         req.sign_request(oauth.OAuthSignatureMethod_HMAC_SHA1(),
                          self.consumer, self.request_token)
-        resp = urllib2.urlopen(req.to_url())
-        access_token_resp = dict(urlparse.parse_qsl(resp.read()))
+        resp = urllib.request.urlopen(req.to_url())
+        access_token_resp = dict(urllib.parse.parse_qsl(resp.read()))
         self.access_token = oauth.OAuthToken(
             access_token_resp["oauth_token"],
             access_token_resp["oauth_token_secret"]
@@ -327,7 +327,7 @@ def set_auth_handler(auth_handler, set_api_keys=False):
         as a conveniency only for single user settings.
     """
     global AUTH_HANDLER
-    if isinstance(auth_handler, basestring):
+    if isinstance(auth_handler, string_types):
         ah = AuthHandler.load(auth_handler, set_api_keys)
         set_auth_handler(ah)
     else:

--- a/flickr_api/keys.py
+++ b/flickr_api/keys.py
@@ -2,7 +2,7 @@ API_KEY = None
 API_SECRET = None
 
 try:
-    import flickr_keys
+    from . import flickr_keys
     API_KEY = flickr_keys.API_KEY
     API_SECRET = flickr_keys.API_SECRET
 except ImportError:

--- a/flickr_api/method_call.py
+++ b/flickr_api/method_call.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 from six.moves import urllib
+from six import iteritems
 import hashlib
 import json
 
@@ -45,10 +46,10 @@ def disable_cache():
 def send_request(url, data):
     """send a http request.
     """
-    req = urllib.request.Request(url, data)
+    req = urllib.request.Request(url, data.encode())
     try:
         return urllib.request.urlopen(req).read()
-    except urllib.request.HTTPError as e:
+    except urllib.error.HTTPError as e:
         raise FlickrError(e.read().split('&')[0])
 
 
@@ -152,7 +153,7 @@ def clean_content(d):
         d_clean = {}
         if len(d) == 1 and "_content" in d:
             return clean_content(d["_content"])
-        for k, v in d.iteritems():
+        for k, v in iteritems(d):
             if k == "_content":
                 k = "text"
             d_clean[k] = clean_content(v)

--- a/flickr_api/method_call.py
+++ b/flickr_api/method_call.py
@@ -127,7 +127,7 @@ def call_api(api_key=None, api_secret=None, auth_handler=None,
         return resp
 
     try:
-        resp = json.loads(resp)
+        resp = json.loads(resp.decode())
     except ValueError as e:
         print (resp)
         raise e

--- a/flickr_api/method_call.py
+++ b/flickr_api/method_call.py
@@ -8,8 +8,9 @@
     Date: 06/08/2011
 
 """
-import urllib2
-import urllib
+from __future__ import print_function
+
+from six.moves import urllib
 import hashlib
 import json
 
@@ -44,10 +45,10 @@ def disable_cache():
 def send_request(url, data):
     """send a http request.
     """
-    req = urllib2.Request(url, data)
+    req = urllib.request.Request(url, data)
     try:
-        return urllib2.urlopen(req).read()
-    except urllib2.HTTPError, e:
+        return urllib.request.urlopen(req).read()
+    except urllib.request.HTTPError as e:
         raise FlickrError(e.read().split('&')[0])
 
 
@@ -108,7 +109,7 @@ def call_api(api_key=None, api_secret=None, auth_handler=None,
             m.update(sig)
             api_sig = m.digest()
             args["api_sig"] = api_sig
-        data = urllib.urlencode(args)
+        data = urllib.parse.urlencode(args)
     else:
         data = auth_handler.complete_parameters(
              url=request_url, params=args
@@ -126,8 +127,8 @@ def call_api(api_key=None, api_secret=None, auth_handler=None,
 
     try:
         resp = json.loads(resp)
-    except ValueError, e:
-        print resp
+    except ValueError as e:
+        print (resp)
         raise e
 
     if resp["stat"] != "ok":

--- a/flickr_api/multipart.py
+++ b/flickr_api/multipart.py
@@ -12,6 +12,7 @@
 """
 
 from six.moves import http_client, urllib
+from six import text_type
 import mimetypes
 
 
@@ -48,31 +49,38 @@ def encode_multipart_formdata(fields, files):
 
     Return (content_type, body) ready for httplib.HTTP instance
     """
-    BOUNDARY = '----------ThIs_Is_tHe_bouNdaRY_$'
-    CRLF = '\r\n'
+    BOUNDARY = b'----------ThIs_Is_tHe_bouNdaRY_$'
+    CRLF = b'\r\n'
     L = []
     for (key, value) in fields:
-        L.append('--' + BOUNDARY)
-        L.append('Content-Disposition: form-data; name="%s"' % key)
-        L.append('')
+        if isinstance(key, text_type):
+            key = key.encode("utf-8")
+        if isinstance(value, text_type):
+            value = value.encode("utf-8")
+        L.append(b'--' + BOUNDARY)
+        L.append(b'Content-Disposition: form-data; name="%s"' % key)
+        L.append(b'')
         L.append(value)
     for (key, filename, value) in files:
-        filename = filename.encode("utf8")
-        L.append('--' + BOUNDARY)
+        if isinstance(key, text_type):
+            key = key.encode("utf8")
+        if isinstance(filename, text_type):
+            filename = filename.encode("utf8")
+        L.append(b'--' + BOUNDARY)
         L.append(
-            'Content-Disposition: form-data; name="%s"; filename="%s"' % (
+            b'Content-Disposition: form-data; name="%s"; filename="%s"' % (
                 key, filename
             )
         )
-        L.append('Content-Type: %s' % get_content_type(filename))
-        L.append('')
+        L.append(b'Content-Type: %s' % get_content_type(filename))
+        L.append(b'')
         L.append(value)
-    L.append('--' + BOUNDARY + '--')
-    L.append('')
+    L.append(b'--' + BOUNDARY + b'--')
+    L.append(b'')
     body = CRLF.join(L)
-    content_type = 'multipart/form-data; boundary=%s' % BOUNDARY
+    content_type = b'multipart/form-data; boundary=%s' % BOUNDARY
     return content_type, body
 
 
 def get_content_type(filename):
-    return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+    return mimetypes.guess_type(filename.decode())[0].encode("utf-8") or 'application/octet-stream'

--- a/flickr_api/multipart.py
+++ b/flickr_api/multipart.py
@@ -11,13 +11,12 @@
 
 """
 
-import httplib
+from six.moves import http_client, urllib
 import mimetypes
-import urlparse
 
 
 def posturl(url, fields, files):
-    urlparts = urlparse.urlsplit(url)
+    urlparts = urllib.parse.urlsplit(url)
     return post_multipart(urlparts[1], urlparts[2], fields, files)
 
 
@@ -31,7 +30,7 @@ def post_multipart(host, selector, fields, files):
     Return the server's response page.
     """
     content_type, body = encode_multipart_formdata(fields, files)
-    h = httplib.HTTPSConnection(host)
+    h = http_client.HTTPSConnection(host)
     headers = {"Content-Type": content_type, 'content-length': str(len(body))}
     h.request("POST", selector, headers=headers)
     h.send(body)

--- a/flickr_api/multipart.py
+++ b/flickr_api/multipart.py
@@ -12,7 +12,7 @@
 """
 
 from six.moves import http_client, urllib
-from six import text_type
+from six import binary_type, text_type
 import mimetypes
 
 
@@ -53,34 +53,35 @@ def encode_multipart_formdata(fields, files):
     CRLF = b'\r\n'
     L = []
     for (key, value) in fields:
-        if isinstance(key, text_type):
-            key = key.encode("utf-8")
+        if isinstance(key, binary_type):
+            key = key.decode()
         if isinstance(value, text_type):
             value = value.encode("utf-8")
         L.append(b'--' + BOUNDARY)
-        L.append(b'Content-Disposition: form-data; name="%s"' % key)
+        L.append(('Content-Disposition: form-data; name="%s"' % key).encode("utf-8"))
         L.append(b'')
         L.append(value)
     for (key, filename, value) in files:
-        if isinstance(key, text_type):
-            key = key.encode("utf8")
-        if isinstance(filename, text_type):
-            filename = filename.encode("utf8")
+        if isinstance(key, binary_type):
+            key = key.decode()
+        if isinstance(filename, binary_type):
+            filename = filename.decode()
         L.append(b'--' + BOUNDARY)
         L.append(
-            b'Content-Disposition: form-data; name="%s"; filename="%s"' % (
-                key, filename
-            )
+            (
+                'Content-Disposition: form-data; name="%s"; filename="%s"' %
+                    (key, filename)
+            ).encode("utf-8")
         )
-        L.append(b'Content-Type: %s' % get_content_type(filename))
+        L.append(('Content-Type: %s' % get_content_type(filename)).encode("utf-8"))
         L.append(b'')
         L.append(value)
     L.append(b'--' + BOUNDARY + b'--')
     L.append(b'')
     body = CRLF.join(L)
-    content_type = b'multipart/form-data; boundary=%s' % BOUNDARY
+    content_type = b'multipart/form-data; boundary=' + BOUNDARY
     return content_type, body
 
 
 def get_content_type(filename):
-    return mimetypes.guess_type(filename.decode())[0].encode("utf-8") or 'application/octet-stream'
+    return mimetypes.guess_type(filename)[0] or 'application/octet-stream'

--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -19,14 +19,13 @@
     email: alexis.mignon_at_gmail.com
     Date: 05/08/2011
 """
-import method_call
-from  flickrerrors import FlickrError
-from reflection import caller, static_caller, FlickrAutoDoc
-import urllib2
-from UserList import UserList
-import auth
+from . import method_call
+from .flickrerrors import FlickrError
+from .reflection import caller, static_caller, FlickrAutoDoc
+from six import text_type
+from six.moves import UserList, urllib, cStringIO
+from . import auth
 import warnings
-from cStringIO import StringIO
 
 try:
     from PIL import Image    
@@ -133,7 +132,7 @@ class FlickrObject(object):
                     pass
             if not val_found:
                 continue
-            if isinstance(value, unicode):
+            if isinstance(value, text_type):
                 value = value.encode("utf8")
             if isinstance(value, str):
                 value = "'%s'" % value
@@ -1317,7 +1316,7 @@ class Photo(FlickrObject):
         """
         if size_label is None:
             size_label = self._getLargestSizeLabel()
-        r = urllib2.urlopen(self.getPhotoFile(size_label))
+        r = urllib.request.urlopen(self.getPhotoFile(size_label))
         with open(filename, 'wb') as f:
             f.write(r.read())
             f.close()
@@ -1344,8 +1343,8 @@ class Photo(FlickrObject):
         """
         if size_label is None:
             size_label = self._getLargestSizeLabel()
-        r = urllib2.urlopen(self.getPhotoFile(size_label))
-        b = StringIO(r.read())
+        r = urllib.reuest.urlopen(self.getPhotoFile(size_label))
+        b = cStringIO(r.read())
         Image.open(b).show()
 
     @static_caller("flickr.photos.getUntagged")

--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -22,8 +22,8 @@
 from . import method_call
 from .flickrerrors import FlickrError
 from .reflection import caller, static_caller, FlickrAutoDoc
-from six import text_type
-from six.moves import UserList, urllib, cStringIO
+from six import text_type, iteritems
+from six.moves import UserList, urllib, cStringIO, range
 from . import auth
 import warnings
 
@@ -1219,7 +1219,7 @@ class Photo(FlickrObject):
         args["date"] = date
         return (
             args,
-            lambda r: dict([(k, int(v)) for k, v in r["stats"].iteritems()])
+            lambda r: dict([(k, int(v)) for k, v in iteritems(r["stats"])])
         )
 
     @caller("flickr.tags.getListPhoto")
@@ -1243,7 +1243,7 @@ class Photo(FlickrObject):
         sizes = self.getSizes()
         max_size = None
         max_area = None
-        for sl, s in sizes.iteritems():
+        for sl, s in iteritems(sizes):
             area = int(s["height"]) * int(s["width"])
             if max_area is None or area > max_area:
                 max_size = sl
@@ -1592,7 +1592,7 @@ class Photoset(FlickrObject):
         args["date"] = date
         return (
             args,
-            lambda r: dict([(k, int(v)) for k, v in r["stats"].iteritems()])
+            lambda r: dict([(k, int(v)) for k, v in iteritems(r["stats"])])
         )
 
     @static_caller("flickr.photosets.orderSets")

--- a/flickr_api/reflection.py
+++ b/flickr_api/reflection.py
@@ -11,6 +11,7 @@
 
 import re
 from functools import wraps
+from six import iteritems
 from . import method_call
 from . import auth
 from .flickrerrors import FlickrError
@@ -140,7 +141,7 @@ class FlickrAutoDoc(type):
     """
     def __new__(meta, classname, bases, classDict):
         self_name = classDict.get("__self_name__", None)
-        for k, v in classDict.iteritems():
+        for k, v in iteritems(classDict):
             ignore_arguments = ["api_key"]
             if hasattr(v, 'flickr_method'):
                 if v.isstatic:

--- a/flickr_api/reflection.py
+++ b/flickr_api/reflection.py
@@ -231,13 +231,13 @@ def caller(flickr_method, static=False):
     """
         This decorator binds a method to the flickr method given
         by 'flickr_method'.
-        The wrapped method should return the argument dictionnary
+        The wrapped method should return the argument dictionary
         and a function that format the result of method_call.call_api.
 
         Some method can propagate authentication tokens. For instance a
         Person object can propagate its token to photos retrieved from
         it. In this case, it should return its token also and the
-        result formating function should take an additional argument
+        result formatting function should take an additional argument
         token.
     """
     def decorator(method):
@@ -245,7 +245,7 @@ def caller(flickr_method, static=False):
         def call(self, *args, **kwargs):
             token, kwargs = _get_token(self, **kwargs)
             method_args, format_result = method(self, *args, **kwargs)
-            method_args[call.__self_name__] = self.id
+            method_args[self.__self_name__] = self.id
             if token:
                 method_args["auth_handler"] = token
             r = method_call.call_api(method=flickr_method, **method_args)

--- a/flickr_api/tools.py
+++ b/flickr_api/tools.py
@@ -1,4 +1,4 @@
-from method_call import call_api
+from .method_call import call_api
 import sys
 import os
 

--- a/flickr_api/upload.py
+++ b/flickr_api/upload.py
@@ -21,6 +21,7 @@ from . import auth
 from . import multipart
 import os
 from xml.etree import ElementTree as ET
+from six import text_type
 
 UPLOAD_URL = "https://api.flickr.com/services/upload/"
 REPLACE_URL = "https://api.flickr.com/services/replace/"
@@ -31,9 +32,9 @@ def format_dict(d):
     for k, v in d.iteritems():
         if isinstance(v, bool):
             v = int(v)
-        elif isinstance(v, unicode):
+        elif isinstance(v, text_type):
             v = v.encode("utf8")
-        if isinstance(k, unicode):
+        if isinstance(k, text_type):
             k = k.encode("utf8")
         v = str(v)
         d_[k] = v

--- a/flickr_api/upload.py
+++ b/flickr_api/upload.py
@@ -21,7 +21,7 @@ from . import auth
 from . import multipart
 import os
 from xml.etree import ElementTree as ET
-from six import text_type, iteritems
+from six import text_type, binary_type, iteritems
 
 UPLOAD_URL = "https://api.flickr.com/services/upload/"
 REPLACE_URL = "https://api.flickr.com/services/replace/"
@@ -36,7 +36,7 @@ def format_dict(d):
             v = v.encode("utf8")
         if isinstance(k, text_type):
             k = k.encode("utf8")
-        v = str(v)
+        v = binary_type(v)
         d_[k] = v
     return d_
 
@@ -45,10 +45,10 @@ def post(url, auth_handler, args, photo_file, photo_file_data=None):
     args = format_dict(args)
     args["api_key"] = auth_handler.key
 
-    params = auth_handler.complete_parameters(url, args).parameters
+    params = auth_handler.complete_parameters(url, args)
 
     fields = params.items()
-    if photo_file_data==None:
+    if photo_file_data is None:
         files = [("photo", os.path.basename(photo_file), open(photo_file, "rb").read())]
     else:
         files = [("photo", os.path.basename(photo_file), photo_file_data.read())]

--- a/flickr_api/upload.py
+++ b/flickr_api/upload.py
@@ -21,7 +21,7 @@ from . import auth
 from . import multipart
 import os
 from xml.etree import ElementTree as ET
-from six import text_type
+from six import text_type, iteritems
 
 UPLOAD_URL = "https://api.flickr.com/services/upload/"
 REPLACE_URL = "https://api.flickr.com/services/replace/"
@@ -29,7 +29,7 @@ REPLACE_URL = "https://api.flickr.com/services/replace/"
 
 def format_dict(d):
     d_ = {}
-    for k, v in d.iteritems():
+    for k, v in iteritems(d):
         if isinstance(v, bool):
             v = int(v)
         elif isinstance(v, text_type):

--- a/samples/download_album.py
+++ b/samples/download_album.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import flickr_api as f
 import sys
 import os
@@ -18,11 +20,11 @@ try :
     for p in ps.getPhotos() :
         p.save(p.title+".jpg")
 except IndexError :
-    print "usage: python download_album.py username album_idx [access_token_file]"
-    print "Downloads the content of a user's album."
-    print "'album_idx' stands of the album index as given by the 'show_albums.py'"
-    print "script. A new directory with the album title will be created and the"
-    print "album content will be downloaded in this directory."
+    print ("usage: python download_album.py username album_idx [access_token_file]")
+    print ("Downloads the content of a user's album.")
+    print ("'album_idx' stands of the album index as given by the 'show_albums.py'")
+    print ("script. A new directory with the album title will be created and the")
+    print ("album content will be downloaded in this directory.")
 
 
 

--- a/samples/download_album.py
+++ b/samples/download_album.py
@@ -14,10 +14,13 @@ try :
     u = f.Person.findByUserName(username)
     ps = u.getPhotosets()[photoset_idx]
 
-    if not os.path.exists(ps.title) : os.mkdir(ps.title)
+    if not os.path.exists(ps.title):
+        print("Creating directory " + ps.title)
+        os.mkdir(ps.title)
     os.chdir(ps.title)
 
     for p in ps.getPhotos() :
+        print("Saving photo " + p.title)
         p.save(p.title+".jpg")
 except IndexError :
     print ("usage: python download_album.py username album_idx [access_token_file]")

--- a/samples/shell.py
+++ b/samples/shell.py
@@ -7,6 +7,8 @@ Description:
   This makes it easier to start playing
   with the Flickr API.
 """
+from __future__ import print_function
+
 import flickr_api
 import sys
 import warnings
@@ -44,5 +46,5 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         main()
     else:
-        print __doc__
+        print (__doc__)
 

--- a/samples/show_albums.py
+++ b/samples/show_albums.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import flickr_api as f
 import sys
 
@@ -12,7 +14,7 @@ try :
     ps = u.getPhotosets()
     
     for i,p in enumerate(ps) :
-        print i,p.title
+        print (i,p.title)
 except IndexError :
-    print "usage: python show_albums.py username [access_token_file]"
-    print "Displays the list of photosets belonging to a user"
+    print ("usage: python show_albums.py username [access_token_file]")
+    print ("Displays the list of photosets belonging to a user")

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,16 @@ setup(
         "six",
     ],
     license="BSD License",
+    classifiers=[
+        'Intended Audience :: Developers',
+
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     packages=["flickr_api"],
     install_requires=[
         "oauth",
+        "six",
     ],
     license="BSD License",
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="http://code.google.com/p/python-flickr-api/",
     packages=["flickr_api"],
     install_requires=[
-        "oauth",
+        "oauth2",
         "six",
     ],
     license="BSD License",


### PR DESCRIPTION
This PR adds Python 3 support using [`six` module](https://github.com/benjaminp/six). Also, it requires to switch from `oauth` to its fork [`oauth2`](https://github.com/joestump/python-oauth2). `oauth2` supports Python 3 but don't compatible with original oauth, so I fix `auth.py` to support it.

This code hasn't been tested enough, I've checked that both samples work on both Python 2 and 3 and checked photos upload. It shouldn't be upload on pypi as a new version of the package as is. However, I ask you to accept this PR and ask community to test it. We can write some unit tests as a next step.