### PR TITLE
Save photo with original file extension

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -1302,7 +1302,7 @@ class Photo(FlickrObject):
             given size.
 
         Arguments:
-            filename: target file name
+            filename: target file name (without extension)
 
             size_label: The label corresponding to the photo size
 
@@ -1316,8 +1316,12 @@ class Photo(FlickrObject):
         """
         if size_label is None:
             size_label = self._getLargestSizeLabel()
-        r = urllib.request.urlopen(self.getPhotoFile(size_label))
-        with open(filename, 'wb') as f:
+            
+        photo_file = self.getPhotoFile(size_label)
+        file_ext = '.' + photo_file.split('.')[-1]
+        r = urllib.request.urlopen(photo_file)
+
+        with open(filename + file_ext, 'wb') as f:
             f.write(r.read())
             f.close()
 


### PR DESCRIPTION
When "saving" (downloading) a photo from Flickr, it should be downloaded with the original file extension i.e. if the photo was uploaded as a _png_, it should be downloaded as a _png_.

To solve this, I've just grabbed the file extension from the photo's source URL and appended it to the filename when writing to the file. 