### PR TITLE
Make iterator Walker compatible with Python 3

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -2138,6 +2138,9 @@ class Walker(object):
                 slice_.step)
         else:
             raise ValueError("Only slices can be used as subscript")
+            
+    def __next__(self):
+        return self.next()
 
     def next(self):
         if self._curr_index == len(self._curr_list):


### PR DESCRIPTION
This is required to avoid this error when run under Python 3:

```
TypeError: iter() returned non-iterator of type 'Walker'
```

A workaround to get around this bug is to monkey patch `Walker`, like this:

```python
flickr_api.Walker.__next__ = flickr_api.Walker.next
```