### PR TITLE
Fix Person.getTags()

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -889,7 +889,7 @@ class Person(FlickrObject):
 
     @caller("flickr.tags.getListUser")
     def getTags(self):
-        return {}, lambda r: [Tag(**t) for t in r["who"]["tags"]["tag"]]
+        return {}, lambda r: [Tag(text=t) for t in r["who"]["tags"]["tag"]]
 
     @caller("flickr.tags.getListUserPopular")
     def getPopularTags(**args):


### PR DESCRIPTION
The [`flickr.tags.getListUser` API method](https://www.flickr.com/services/api/flickr.tags.getListUser.html) only returns tag texts, and therefore the Tag objects have to be created with the explicit `text=` named argument.
