### PR TITLE
api.py - change sort() call to sorted() to address python3 error

### DIFF
--- a/flickr_api/api.py
+++ b/flickr_api/api.py
@@ -17,7 +17,7 @@ from . import auth
 from . import reflection
 
 __methods__ = reflection.__methods__.keys()
-__methods__.sort()
+__methods__ = sorted(__methods__)
 
 __proxys__ = {}
 


### PR DESCRIPTION
This addresses the python3 error mentioned in issue #99. 