### PR TITLE
Fix Emacs local variables line

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf8 -*-
+# -*- encoding: utf-8 -*-
 """
     Object Oriented implementation of Flickr API.
 


### PR DESCRIPTION
The correctly encoding name is `utf-8` not `utf8`