### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A brief guide is available in the [Wiki section](https://github.com/alexis-migno
 * [Album Sorter](https://github.com/Scraft/flickr-album-sorter) - Sort flickr albums into date taken order
 
 ## Development
-This project uses pipenv to create a virtualenv for developement and control dependencies.
+This project uses pipenv to create a virtualenv for development and control dependencies.
 
 To run tests you can simply run it with:
 ```

--- a/flickr_api/api.py
+++ b/flickr_api/api.py
@@ -25,7 +25,7 @@ __proxys__ = {}
 def _get_proxy(name):
     """
         return the FlickrMethodProxy object with called 'name' from 
-        the __proxys__ global dictionnary. Creates the objects if needed.
+        the __proxys__ global dictionary. Creates the objects if needed.
     """
     if name in __proxys__ :
         return __proxys__[name]

--- a/flickr_api/auth.py
+++ b/flickr_api/auth.py
@@ -172,7 +172,7 @@ class AuthHandler(object):
 
     include_api_keys: bool, optional (default False)
         Should we include the api keys in the file ? For security issues, it
-        is recommanded not to save the API keys information in several places
+        is recommended not to save the API keys information in several places
         and the default behaviour is thus not to save the API keys.
 """
         if self.access_token is None:
@@ -222,7 +222,7 @@ class AuthHandler(object):
         If API keys are found in the file, should we use them to set the
         API keys globally.
         Default is False. The API keys should be stored separately from
-        authentication information. The recommanded way is to use a
+        authentication information. The recommended way is to use a
         `flickr_keys.py` file. Setting `set_api_keys=True` should be considered
         as a conveniency only for single user settings.
 """
@@ -241,7 +241,7 @@ class AuthHandler(object):
         If API keys are found in the file, should we use them to set the
         API keys globally.
         Default is False. The API keys should be stored separately from
-        authentication information. The recommanded way is to use a
+        authentication information. The recommended way is to use a
         `flickr_keys.py` file. Setting `set_api_keys=True` should be considered
         as a conveniency only for single user settings.
 """
@@ -316,7 +316,7 @@ def set_auth_handler(auth_handler, set_api_keys=False):
         If API keys are found in the file, should we use them to set the
         API keys globally.
         Default is False. The API keys should be stored separately from
-        authentication information. The recommanded way is to use a
+        authentication information. The recommended way is to use a
         `flickr_keys.py` file. Setting `set_api_keys=True` should be considered
         as a conveniency only for single user settings.
     """

--- a/flickr_api/method_call.py
+++ b/flickr_api/method_call.py
@@ -79,7 +79,7 @@ def call_api(api_key=None, api_secret=None, auth_handler=None,
             is used.
         raw:
             if True the default xml response from the server is returned. If
-            False (default) a dictionnary built from the JSON answer is
+            False (default) a dictionary built from the JSON answer is
             returned.
         args:
             the arguments to pass to the method.
@@ -156,11 +156,11 @@ def call_api(api_key=None, api_secret=None, auth_handler=None,
 
 def clean_content(d):
     """
-    Cleans out recursively the keys comming from the JSON
-    dictionnary.
+    Cleans out recursively the keys coming from the JSON
+    dictionary.
 
     Namely: "_content" keys are replaces with their associated
-        values if they are the only key of the dictionnary. Other
+        values if they are the only key of the dictionary. Other
         wise they are replaces by a "text" key with the same value.
     """
     if isinstance(d, dict):

--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -167,7 +167,7 @@ class FlickrObject(with_metaclass(FlickrAutoDoc, object)):
 
     def getInfo(self):
         """
-            Returns object information as a dictionnary.
+            Returns object information as a dictionary.
             Should be overriden.
         """
         return {}

--- a/flickr_api/reflection.py
+++ b/flickr_api/reflection.py
@@ -275,7 +275,7 @@ def static_caller(flickr_method, static=False):
     """
         This decorator binds a static method to the flickr method given
         by 'flickr_method'.
-        The wrapped method should return the argument dictionnary
+        The wrapped method should return the argument dictionary
         and a function that format the result of method_call.call_api.
 
         Some method can propagate authentication tokens. For instance a

--- a/flickr_api/upload.py
+++ b/flickr_api/upload.py
@@ -81,7 +81,7 @@ def upload(**args):
         description (optional)
             A description of the photo. May contain some limited HTML.
         tags (optional)
-            A space-seperated list of tags to apply to the photo.
+            A space-separated list of tags to apply to the photo.
         is_public, is_friend, is_family (optional)
             Set to 0 for no, 1 for yes. Specifies who can view the photo.
         safety_level (optional)


### PR DESCRIPTION
There are small typos in:
- README.md
- flickr_api/api.py
- flickr_api/auth.py
- flickr_api/method_call.py
- flickr_api/objects.py
- flickr_api/reflection.py
- flickr_api/upload.py

Fixes:
- Should read `dictionary` rather than `dictionnary`.
- Should read `recommended` rather than `recommanded`.
- Should read `separated` rather than `seperated`.
- Should read `development` rather than `developement`.
- Should read `coming` rather than `comming`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md