### PR TITLE
Implement __next__ method for SlicedWalker

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -2240,6 +2240,9 @@ class SlicedWalker(object):
     def __iter__(self):
         return self
 
+    def __next__(self):
+        return self.next()
+
     def next(self):
         if self._begin:
             for i in range(self.start):


### PR DESCRIPTION
Fixes
```
TypeError: iter() returned non-iterator of type 'SlicedWalker'
```

As `Walker` has the `__next__` method implemented and can be iterated over, `SlicedWalker` also needs it 