### PR TITLE
Fix mypy errors, add mypy config, and run mypy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run ruff format check
         run: uv run ruff format --check flickr_api/
 
+      - name: Run mypy
+        run: uv run mypy flickr_api/
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/flickr_api/method_call.py
+++ b/flickr_api/method_call.py
@@ -165,8 +165,12 @@ def get_rate_limit_status() -> dict[str, Any]:
         - interval_seconds: float - Minimum time between requests (0.0 if disabled)
         - last_request_time: float | None - Timestamp of last request
     """
-    enabled = _RATE_LIMIT_REQUESTS_PER_HOUR is not None
-    interval = 3600.0 / _RATE_LIMIT_REQUESTS_PER_HOUR if enabled else 0.0
+    if _RATE_LIMIT_REQUESTS_PER_HOUR is not None:
+        enabled = True
+        interval = 3600.0 / _RATE_LIMIT_REQUESTS_PER_HOUR
+    else:
+        enabled = False
+        interval = 0.0
     return {
         "enabled": enabled,
         "requests_per_hour": _RATE_LIMIT_REQUESTS_PER_HOUR,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,17 @@ testpaths = ["test"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.mypy]
+python_version = "3.10"
+
+# Third-party libraries without type information. `requests_oauthlib` ships no
+# stubs, and `PIL` (Pillow) is an optional runtime dependency that is not
+# installed by default.
+[[tool.mypy.overrides]]
+module = [
+    "requests_oauthlib",
+    "PIL",
+    "PIL.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

Makes `uv run mypy flickr_api/` pass cleanly (was 3 errors) and wires mypy into CI so type errors are caught going forward.

## Changes

- **`method_call.py`** — narrow `_RATE_LIMIT_REQUESTS_PER_HOUR` with an explicit `if/else` in `get_rate_limit_status()`, fixing the `float / None` operand error without duplicating the `None` check.
- **`pyproject.toml`** — add a `[tool.mypy]` section with `ignore_missing_imports` overrides for:
  - `requests_oauthlib` — ships no type stubs
  - `PIL` (Pillow) — an optional runtime dependency, not installed by default
- **`.github/workflows/ci.yml`** — add a `mypy` step to the lint job so type errors are caught in CI and don't regress.

## Verification

- `uv run mypy flickr_api/` — **Success: no issues found** (was 3 errors)
- `uv run flake8 flickr_api/` — clean
- `uv run ruff check flickr_api/` — clean
- `uv run ruff format --check flickr_api/` — clean
- `uv run pytest` — **282 passed**