### PR TITLE
Clarify safety_level get/set index mismatch is intentional (#173)

### DIFF
--- a/flickr_api/objects.py
+++ b/flickr_api/objects.py
@@ -995,6 +995,11 @@ class Photo(FlickrObject):
         ),
         dict_converter(["posted", "lastupdate"], int),
         dict_converter(["views", "comments"], int),
+        # Kept 0-indexed exactly as Flickr returns it from getInfo/search
+        # (0=safe, 1=moderate, 2=restricted). This intentionally differs by
+        # one from setSafetyLevel, which is 1-indexed (1=safe, 2=moderate,
+        # 3=restricted): the asymmetry is in the Flickr API, and we mirror it
+        # rather than normalise it. See Photo.getSafetyLevel().
         dict_converter(["safety_level"], int),
     ]
     __display__ = ["id", "title"]
@@ -1190,9 +1195,27 @@ class Photo(FlickrObject):
         method, so the value is read from ``flickr.photos.getInfo`` (loading
         the photo first if it has not been loaded yet).
 
-        Returns an integer safety level:
-        ``0`` (none), ``1`` (safe), ``2`` (moderate) or ``3`` (restricted).
-        These match the values accepted by :meth:`setSafetyLevel`.
+        This returns the raw value exactly as Flickr reports it through
+        ``getInfo`` / ``search`` (identical to the :attr:`safety_level`
+        attribute), intentionally left un-normalised so it mirrors the
+        underlying API. That scale is **0-indexed**:
+
+        - ``0`` -- safe
+        - ``1`` -- moderate
+        - ``2`` -- restricted
+
+        .. warning::
+            By design these values do **not** match :meth:`setSafetyLevel`.
+            This mismatch is not a bug in this library: it reflects a
+            long-standing asymmetry in the Flickr API itself, where
+            ``flickr.photos.getInfo`` reports the 0-indexed value above but
+            ``flickr.photos.setSafetyLevel`` expects a **1-indexed** value
+            (``1`` safe, ``2`` moderate, ``3`` restricted). We deliberately
+            pass both through unchanged rather than hide the discrepancy. To
+            feed a level read here back into :meth:`setSafetyLevel`, add one::
+
+                level = photo.getSafetyLevel()            # 0 / 1 / 2
+                photo.setSafetyLevel(safety_level=level + 1)
         """
         if not hasattr(self, "safety_level"):
             self.load()


### PR DESCRIPTION
## Summary

Fixes the misleading `Photo.getSafetyLevel()` docstring shipped in #174 / 0.8.1.

`getSafetyLevel()` returns Flickr's **raw 0-indexed** value from `getInfo`/`search` (`0`=safe, `1`=moderate, `2`=restricted), but `flickr.photos.setSafetyLevel` expects a **1-indexed** value (`1`=safe, `2`=moderate, `3`=restricted). The old docstring wrongly claimed the two scales matched, so following its own example would set the wrong safety level (reported in #173).

This is a **long-standing asymmetry in the Flickr API itself**, not a bug in this library — we intentionally pass both values through unchanged rather than normalise them. This PR makes that explicit.

## Changes (docs only, no behaviour change)

- Rewrite the `getSafetyLevel()` docstring: document the real 0-indexed scale, state the mismatch with `setSafetyLevel` is by design, and show the `+1` conversion for round-tripping.
- Add a matching note at the `safety_level` converter so readers of the raw attribute see the same caveat.

## Verification

Confirmed the 0-indexed `getInfo` scale against independent sources:
- Flickr's official [`setSafetyLevel` docs](https://www.flickr.com/services/api/flickr.photos.setSafetyLevel.html) — 1-indexed setter.
- The Flickr Foundation's own [`flickr-photos-api`](https://github.com/Flickr-Foundation/flickr-photos-api) `parse_safety_level()` — maps `getInfo` `0/1/2` → safe/moderate/restricted.
- A recorded real `getInfo` response in that repo returning `safety_level="0"` for a safe photo.

Existing `test/test_photos.py` passes (38 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)